### PR TITLE
Fix file import functionality in MpzIdentityReader

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -17,6 +17,10 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" 
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
 
     <!-- Bluetooth permissions for Android 12+ (API level >= 31) -->
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"

--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/TrustedIssuersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/TrustedIssuersScreen.kt
@@ -143,6 +143,10 @@ fun TrustedIssuersScreen(
             "application/x-x509-key; format=pem",
             "application/x-x509-cert; format=pem",
             "application/x-x509-ca-cert",
+            "application/x-x509-ca-cert; format=der",
+            "application/pkix-cert",
+            "application/pkix-crl",
+            "*/*",
         ),
         allowMultiple = false,
         onResult = { files ->


### PR DESCRIPTION
Hey @davidz25 — I know you're not expecting any commits in these repos, but I ran into this issue and thought I’d share it while it’s fresh in my mind. Feel free to do whatever makes sense — take it, tweak it, or disregard it completely. Just wanted to flag it in case it’s helpful!

## The Issue
I was testing MpzIdentityReader on a non-GMS Android 12 device and hit a roadblock: the file picker couldn't access certificate files for import. The "Import Certificate" button was there, but when I tried to select .cer/.pem/.crt files, it would either fail silently or not show the files at all.

## What I Found
The app was missing some storage permissions that are needed for file access on certain Android devices, especially non-GMS ones where the file picker behavior can be different.

## What I Did
- Added `READ_EXTERNAL_STORAGE` permission for Android < 33 compatibility
- Added `MANAGE_EXTERNAL_STORAGE` permission for Android 11+ file access  
- Enhanced the certificate file picker MIME types to support:
  * DER format certificates (`application/x-x509-ca-cert; format=der`)
  * Standard PKIX certificates (`application/pkix-cert`, `application/pkix-crl`)
  * All file types fallback (`*/*`) for better compatibility

## Result
After these changes, certificate file import works smoothly on the problematic device. Users can now successfully import certificate files into the trusted issuers list through the floating action button menu.

This should fix the issue where certificate files couldn't be opened/imported due to missing storage permissions and limited MIME type support.

CC: @vishnusanal @hanluOMH