### PR TITLE
feat: Add Reader Root Certificate extraction for holder apps

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/App.kt
@@ -231,6 +231,8 @@ class App(
                 while (true) {
                     ensureReaderKeys()
                     updateBuiltInIssuers()
+                    // Print Reader Root Certificate for easy extraction
+                    readerBackendClient.printReaderRootCertificate()
                     delay(4.hours)
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/ReaderBackendClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/ReaderBackendClient.kt
@@ -491,6 +491,31 @@ open class ReaderBackendClient(
         }
     }
 
+    /**
+     * Prints the Reader Root Certificate in PEM format for easy extraction.
+     * This is useful for users who need to import the certificate into their holder apps.
+     */
+    suspend fun printReaderRootCertificate() {
+        try {
+            val (keyInfo, certChain) = getKey()
+            if (certChain.certificates.size >= 2) {
+                val readerRootCert = certChain.certificates.last() // Last certificate is the root
+                println("=== READER ROOT CERTIFICATE FOR HOLDER APPS ===")
+                println("Subject: ${readerRootCert.subject}")
+                println("Issuer: ${readerRootCert.issuer}")
+                println("Valid from: ${readerRootCert.validityNotBefore}")
+                println("Valid until: ${readerRootCert.validityNotAfter}")
+                println("PEM:")
+                println(readerRootCert.toPem())
+                println("=== END READER ROOT CERTIFICATE ===")
+            } else {
+                println("=== WARNING: Certificate chain too short, cannot extract root certificate ===")
+            }
+        } catch (e: Throwable) {
+            println("=== ERROR: Could not extract Reader Root Certificate: $e ===")
+        }
+    }
+
     companion object {
         private const val TAG = "ReaderBackendClient"
     }


### PR DESCRIPTION
Add printReaderRootCertificate() function that prints the Reader Root Certificate in PEM format when the app starts. This makes it easy for users to copy-paste the certificate into their holder apps for trust establishment.

The certificate is automatically extracted from the certificate chain and includes metadata for verification.

Tests: Manually tested on the Reader app and with the Get Started holder app.

CC - @hanluOMH @vishnusanal